### PR TITLE
Scheduling

### DIFF
--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -21,17 +21,28 @@ class LeaguesController < ApplicationController
 
   def show
     @league = League.find(params[:id])
+    matches=Hash.new{|h, k| h[k] = []}
+    @league.matches.each{|match| matches[match.starts_at]<<match}
+
+    @matches = matches.values
   end
 
   def update
     @league = League.find(params[:id])
-    if params[:status]==League.statuses[:active].to_s&&League.statuses[@league.status]==League.statuses[:inactive]
-      @league.start
-      redirect_to @league, notice: 'League activated'
-    elsif params[:status]==League.statuses[:inactive].to_s&&League.statuses[@league.status]==League.statuses[:active]
-      @league.end
-      redirect_to @league, notice: 'League couldnt be activated'
+    if params[:status]!=nil
+      if params[:status]==League.statuses[:active].to_s&&League.statuses[@league.status]==League.statuses[:inactive]
+        @league.start
+        redirect_to @league, notice: 'League started'
+      elsif params[:status]==League.statuses[:inactive].to_s&&League.statuses[@league.status]==League.statuses[:active]
+        @league.end
+        redirect_to @league, notice: 'League ended'
+      else
+        flash[:error] = "League is already {@league.status}"
+        #redirect_to @league, notice: 'League is already #{@league.status}'
+        redirect_to @league
+      end
     end
+
 
   end
 
@@ -41,7 +52,7 @@ class LeaguesController < ApplicationController
   end
 
   def edit
-    SchedulerDoubleRR.new.schedule_season(League.find(params[:id]))
+
   end
 
   private

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -29,7 +29,7 @@ class LeaguesController < ApplicationController
   end
 
   def edit
-    SchedulerDoubleRR.new.schedule_season(League.find(params[:id]).teams)
+    SchedulerDoubleRR.new.schedule_season(League.find(params[:id]))
   end
 
   private

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -23,6 +23,18 @@ class LeaguesController < ApplicationController
     @league = League.find(params[:id])
   end
 
+  def update
+    @league = League.find(params[:id])
+    if params[:status]==League.statuses[:active].to_s&&League.statuses[@league.status]==League.statuses[:inactive]
+      @league.start
+      redirect_to @league, notice: 'League activated'
+    elsif params[:status]==League.statuses[:inactive].to_s&&League.statuses[@league.status]==League.statuses[:active]
+      @league.end
+      redirect_to @league, notice: 'League couldnt be activated'
+    end
+
+  end
+
   def user_index
     @leagues = current_user.leagues
     render :index

--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -28,6 +28,10 @@ class LeaguesController < ApplicationController
     render :index
   end
 
+  def edit
+    SchedulerDoubleRR.new.schedule_season(League.find(params[:id]).teams)
+  end
+
   private
     def league_params
       params.require(:league).permit(:name, :level)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -9,6 +9,10 @@ class TeamsController < ApplicationController
 
   def show
     @team = Team.find(params[:id])
+
+    #matches=Hash.new{|h, k| h[k] = []}
+    #@team.matches.each{|match| matches[match.starts_at]<<match}
+    @matches = @team.matches
   end
 
   def new

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -10,10 +10,12 @@ class League < ActiveRecord::Base
   enum status: { inactive: 0, active: 1 }
 
   def start
+    SchedulerDoubleRR.new.schedule_season(self)
     active!
   end
 
   def end
+    Match.destroy_all(:status=> Match.statuses[:scheduled],:league=>self)
     inactive!
   end
 

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -7,6 +7,16 @@ class League < ActiveRecord::Base
 
   validates_inclusion_of :level, in: 1..3
 
+  enum status: { inactive: 0, active: 1 }
+
+  def start
+    active!
+  end
+
+  def end
+    inactive!
+  end
+
   def schedule_match(team_a, team_b, time=1.day.from_now)
     self.matches.create(teamA: team_a, teamB: team_b, starts_at: time)
   end

--- a/app/models/scheduler_double_rr.rb
+++ b/app/models/scheduler_double_rr.rb
@@ -5,13 +5,12 @@ class SchedulerDoubleRR
 
     season_start=1.week.from_now.beginning_of_week+20.hour
     season_length=decide_on_season_length(teams.size)
-    for i in 0..season_length-1
-      puts season_start+i.day
-    end
 
     #puts match_pairings(teams)
-    days=assign_parings_to_days(match_pairings(teams),season_length)
+    #days=assign_parings_to_days(match_pairings(teams),season_length)
+    days=assign_matches(teams,season_length)
     for i in 0..season_length-1
+      puts season_start+i.day
       puts days[i]
       puts "\n"
     end
@@ -20,10 +19,86 @@ class SchedulerDoubleRR
   end
 
   private
+    #error with only two teams, only one match is scheduled, error with 0 or 1 teams
+    def assign_matches(t, season_length)
+      schedule=Array.new(season_length){[]}
+      teams=Array(t)
+
+      if (teams.length%2!=0)
+        teams.push(nil)
+      end
+
+      top=teams.take(teams.length/2)
+      bottom=teams.drop(teams.length/2)
+
+      #round1
+      (0..teams.length-2).each do |day|
+        (0..top.length).each do |team|
+          schedule[day] << Pairing.new(top[team], bottom[team])
+        end
+        rotate(top,bottom)
+      end
+      #round2
+      (0..teams.length-2).each do |day|
+        (0..top.length).each do |team|
+          schedule[teams.length-1+day] << Pairing.new(bottom[team], top[team])
+        end
+        rotate(top,bottom)
+      end
+
+      #delete pauses from match schedule
+      schedule.each do |day|
+        day.compact
+        day.delete_if{|match| match.contains_nil}
+      end
+
+      #make sure more or less the same number of matches is scheduled each day
+      while (is_badly_distributed(schedule)) do
+        if(!redistribute(schedule))
+          break
+        end
+      end
+
+      schedule
+    end
+
+    #doesn't distribute perfectly
+    def redistribute(schedule)
+      max=schedule.max_by {|element| element.length}
+
+      schedule.each do |day|
+        if (day.length<max.length-1)
+          if(day.all?{|match| !match.contains_same_team(max.last)})
+            day<<max.pop
+            return true
+          end
+        end
+      end
+      return false
+    end
+
+    def is_badly_distributed(schedule)
+      max=schedule.max_by {|element| element.length}.length
+      min=schedule.min_by {|element| element.length}.length
+      if(max-min>=2)
+        return true
+      else
+        return false
+      end
+    end
+
+    def rotate(top, bottom)
+      bottom<<top.pop
+      top.insert(1,bottom.first)
+      bottom.delete_at(0)
+    end
+
+
     def assign_parings_to_days(parings,season_length)
       days=Array.new(season_length){[]}
 
       i=0
+      tries=0
       while(parings.size!=0)
         twoMatchesPerDay=false
         days[i].each do |match|
@@ -33,6 +108,12 @@ class SchedulerDoubleRR
         end
         if(!twoMatchesPerDay)
           days[i] << parings.pop
+          tries=0
+        else
+          tries=tries+1
+        end
+        if(tries==season_length)
+          puts "no free days"
         end
         i=(i+1)%season_length
       end
@@ -52,7 +133,7 @@ class SchedulerDoubleRR
     end
 
     def decide_on_season_length(number_of_teams)
-      best=-1
+      best=-1 #problem if no better lenght is found (e.g. n_o_t=0||1) this stays
       matches=number_of_matches(number_of_teams)
       opt=optimal_matches_per_day(number_of_teams)
       [7,14].each do |i|
@@ -97,6 +178,10 @@ class SchedulerDoubleRR
 
     def inspect
       "#{@teams[0]} | #{@teams[1]}"
+    end
+
+    def contains_nil
+      @teams[0]==nil||@teams[1]==nil
     end
 
   end

--- a/app/models/scheduler_double_rr.rb
+++ b/app/models/scheduler_double_rr.rb
@@ -1,0 +1,103 @@
+class SchedulerDoubleRR
+  def schedule_season(teams)
+    puts 'scheduled'
+    #puts Date.beginning_of_week
+
+    season_start=1.week.from_now.beginning_of_week+20.hour
+    season_length=decide_on_season_length(teams.size)
+    for i in 0..season_length-1
+      puts season_start+i.day
+    end
+
+    #puts match_pairings(teams)
+    days=assign_parings_to_days(match_pairings(teams),season_length)
+    for i in 0..season_length-1
+      puts days[i]
+      puts "\n"
+    end
+
+    #puts teams
+  end
+
+  private
+    def assign_parings_to_days(parings,season_length)
+      days=Array.new(season_length){[]}
+
+      i=0
+      while(parings.size!=0)
+        twoMatchesPerDay=false
+        days[i].each do |match|
+          if(match.contains_same_team(parings.last))
+            twoMatchesPerDay=true
+          end
+        end
+        if(!twoMatchesPerDay)
+          days[i] << parings.pop
+        end
+        i=(i+1)%season_length
+      end
+      days
+    end
+
+    def match_pairings(teams)
+      pairings=[]
+
+      teams.each do |a|
+        teams.each do |b|
+          pairings << Pairing.new(a,b) unless a == b
+        end
+      end
+
+      pairings
+    end
+
+    def decide_on_season_length(number_of_teams)
+      best=-1
+      matches=number_of_matches(number_of_teams)
+      opt=optimal_matches_per_day(number_of_teams)
+      [7,14].each do |i|
+        if (matches/i-opt).abs<(matches/best-opt).abs
+          best=i
+        end
+      end
+      best
+    end
+
+    def optimal_matches_per_day(number_of_teams)
+      ((number_of_teams/2).floor).abs
+    end
+
+    def number_of_matches(number_of_teams)
+      number_of_teams*(number_of_teams-1)*2
+    end
+
+  class Pairing
+    def initialize(a,b)
+      @teams=[a,b]
+    end
+
+    def contains_same_team(pairing)
+      @teams.each do |t1|
+        pairing.teams.each do |t2|
+          if (t1==t2)
+            return true
+          end
+        end
+      end
+      false
+    end
+
+    def teams
+      @teams
+    end
+
+    def to_s
+      "#{@teams[0]} | #{@teams[1]}"
+    end
+
+    def inspect
+      "#{@teams[0]} | #{@teams[1]}"
+    end
+
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -27,4 +27,13 @@ class Team < ActiveRecord::Base
     end
     super
   end
+
+  def inspect
+    self.name
+  end
+
+  def to_s
+    self.name
+  end
+
 end

--- a/app/views/leagues/_matchTables.html.slim
+++ b/app/views/leagues/_matchTables.html.slim
@@ -1,0 +1,30 @@
+div class="panel panel-primary"
+  div class="panel-heading"
+    h4 class="panel-title"
+    /a data-toggle="collapse" data-parent="#accordion" href="#accordionOne" Collapsible Accordion 1
+    a data-toggle="collapse" href="#matches" >>Matches
+    div id="matches" class="panel-collapse collapse"
+      div class="panel-body"
+
+        -(0..@matches.length-1).each do |day|
+          div class="panel panel-default"
+            div class="panel-heading"
+              h4 class="panel-title"
+              /a data-toggle="collapse" data-parent="#accordion" href="#accordionOne" Collapsible Accordion 1
+              a data-toggle="collapse" href="#accordion#{day}" #{@matches[day][0].starts_at}
+              div id="accordion#{day}" class="panel-collapse collapse"
+                div class="panel-body"
+                  table class="table table-default"
+                    thead
+                      tr
+                        /th= Match.human_attribute_name(:starts_at)
+                        th= Match.human_attribute_name(:Home)
+                        th= Match.human_attribute_name(:Guest)
+                        th= Match.human_attribute_name(:status)
+                    tbody
+                      - @matches[day].each do |match|
+                        tr
+                          /#td= match.starts_at
+                          td= match.teamA.name
+                          td= match.teamB.name
+                          td= match.status

--- a/app/views/leagues/show.html.slim
+++ b/app/views/leagues/show.html.slim
@@ -14,9 +14,17 @@ p
   strong= model_class.human_attribute_name(:owner_id) + ':'
   br
   = @league.owner_id
+p
+  strong= model_class.human_attribute_name(:status) + ':'
+  br
+  = @league.status
 
 = link_to t('.back', :default => t("helpers.links.back")), leagues_path, :class => 'btn btn-default'
 '
 = link_to t('.edit', :default => t("helpers.links.edit")), edit_league_path(@league), :class => 'btn btn-default'
+'
+= link_to t('.update', :default => t("helpers.links.update")), league_path(@league,:status => League.statuses[:active]),:method=>"put", :class => 'btn btn-default'
+'
+= link_to t('.update', :default => t("helpers.links.update")), league_path(@league,:status => League.statuses[:inactive]),:method=>"put", :class => 'btn btn-default'
 '
 = link_to t('.destroy', :default => t("helpers.links.destroy")), league_path(@league), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'

--- a/app/views/leagues/show.html.slim
+++ b/app/views/leagues/show.html.slim
@@ -23,8 +23,13 @@ p
 '
 = link_to t('.edit', :default => t("helpers.links.edit")), edit_league_path(@league), :class => 'btn btn-default'
 '
-= link_to t('.update', :default => t("helpers.links.update")), league_path(@league,:status => League.statuses[:active]),:method=>"put", :class => 'btn btn-default'
+= link_to t('.start', :default => t("helpers.links.start")), league_path(@league,:status => League.statuses[:active]),:method=>"put", :class => 'btn btn-primary'
 '
-= link_to t('.update', :default => t("helpers.links.update")), league_path(@league,:status => League.statuses[:inactive]),:method=>"put", :class => 'btn btn-default'
+= link_to t('.stop', :default => t("helpers.links.stop")), league_path(@league,:status => League.statuses[:inactive]),:method=>"put", :class => 'btn btn-primary'
 '
 = link_to t('.destroy', :default => t("helpers.links.destroy")), league_path(@league), :method => "delete", :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) }, :class => 'btn btn-danger'
+
+p
+
+-if @matches.length!=0
+  == render 'matchTables'

--- a/app/views/teams/show.html.slim
+++ b/app/views/teams/show.html.slim
@@ -3,3 +3,26 @@ h1= "Team #{@team.name}"
 h4 Players
 - @team.players.each do |player|
   p= player.name
+
+-if @matches.length!=0
+  div class="panel panel-primary"
+    div class="panel-heading"
+      h4 class="panel-title"
+      /a data-toggle="collapse" data-parent="#accordion" href="#accordionOne" Collapsible Accordion 1
+      a data-toggle="collapse" href="#accordion" Matches
+      div id="accordion" class="panel-collapse collapse"
+        div class="panel-body"
+          table class="table table-default"
+            thead
+              tr
+                th= Match.human_attribute_name(:starts_at)
+                th= Match.human_attribute_name(:Home)
+                th= Match.human_attribute_name(:Guest)
+                th= Match.human_attribute_name(:status)
+            tbody
+              - @matches.each do |match|
+                tr
+                  td= match.starts_at
+                  td= match.teamA.name
+                  td= match.teamB.name
+                  td= match.status

--- a/config/locales/en.bootstrap.yml
+++ b/config/locales/en.bootstrap.yml
@@ -16,6 +16,8 @@ en:
       destroy: "Delete"
       new: "New"
       edit: "Edit"
+      start: "Start"
+      end: "End"
     titles:
       edit: "Edit %{model}"
       save: "Save %{model}"

--- a/db/migrate/20151022115430_add_status_to_leagues.rb
+++ b/db/migrate/20151022115430_add_status_to_leagues.rb
@@ -1,0 +1,5 @@
+class AddStatusToLeagues < ActiveRecord::Migration
+  def change
+    add_column :leagues, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151022113351) do
+ActiveRecord::Schema.define(version: 20151022115430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,9 +19,10 @@ ActiveRecord::Schema.define(version: 20151022113351) do
   create_table "leagues", force: :cascade do |t|
     t.string   "name"
     t.integer  "level"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.integer  "owner_id"
+    t.integer  "status",     default: 0
   end
 
   add_index "leagues", ["owner_id"], name: "index_leagues_on_owner_id", using: :btree

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe League, type: :model do
     expect(@league.teams.count).to be > 0
   end
 
+  it 'should be inactive as default' do
+    league=League.create!(name:'inac League', level:2)
+    expect(league.status).to eq ('inactive')
+  end
+
+  it 'can be set active' do
+    league=League.create!(name:'inac League', level:2)
+    league.start
+    expect(league.status).to eq ('active')
+  end
+
   it 'should have players through team' do
     expect(@league.players.count).to be > 0
   end

--- a/spec/models/scheduler_double_rr_spec.rb
+++ b/spec/models/scheduler_double_rr_spec.rb
@@ -107,6 +107,6 @@ RSpec.describe SchedulerDoubleRR, type: :model do
     end
     @league.start
     @league.end
-    expect(@league.matches.length).to eq(0)
+    expect(@league.reload.matches.length).to eq(0)
   end
 end

--- a/spec/models/scheduler_double_rr_spec.rb
+++ b/spec/models/scheduler_double_rr_spec.rb
@@ -84,4 +84,29 @@ RSpec.describe SchedulerDoubleRR, type: :model do
     schedule=@scheduler.schedule_season(@league)
     expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
   end
+
+  it 'can schedule 8 teams' do
+    (1..8).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'should schedule matches on league activation' do
+    (1..4).each do
+      add_team_to_league
+    end
+    @league.start
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'should delete not played matches on league stop' do
+    (1..4).each do
+      add_team_to_league
+    end
+    @league.start
+    @league.end
+    expect(@league.matches.length).to eq(0)
+  end
 end

--- a/spec/models/scheduler_double_rr_spec.rb
+++ b/spec/models/scheduler_double_rr_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe SchedulerDoubleRR, type: :model do
+
+  before(:each) do
+    Team.delete_all
+    User.delete_all
+    Match.delete_all
+    @league = League.create!(level: 2)
+    @user = Fabricate(:user, username: 'User')
+    @scheduler=SchedulerDoubleRR.new
+  end
+
+  def add_team_to_league
+    Team.create!(name: 'just a team', strength: 50, league: @league, teamable: @user)
+  end
+
+  it 'cant schedule 0 teams' do
+    (1..0).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+  end
+
+  it 'cant schedule 1 teams' do
+    (1..1).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+  end
+
+  it 'schedule 2 teams' do
+    (1..2).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 3 teams' do
+    (1..3).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 4 teams' do
+    (1..4).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 5 teams' do
+    (1..5).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 6 teams' do
+    (1..6).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 7 teams' do
+    (1..7).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+
+  it 'can schedule 8 teams' do
+    (1..8).each do
+      add_team_to_league
+    end
+    schedule=@scheduler.schedule_season(@league)
+    expect(@league.matches.length).to eq(@league.teams.length*(@league.teams.length-1))
+  end
+end


### PR DESCRIPTION
Added scheduling functionality. Scheduling starts when league is activated. Optimal season length from a pool of possible season lengths is determined by the number of teams. Scheduling supports at max 8 teams atm, extends possible season length array to allow more.